### PR TITLE
NewsPicksのTwittercardがスマホではレイアウトをぶち抜いて表示されてしまう件。

### DIFF
--- a/archive-newspicks.php
+++ b/archive-newspicks.php
@@ -56,7 +56,7 @@
 																			</div>
 																			<div class="col-xs-12 purewhitebg blog-card-title">
 																				<p class="small-text"><?php the_time('Y/m/d'); ?></p>
-																				<h3 class="small-text font-bold"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h3>
+																				<h3 class="small-text font-bold"><a href="<?php the_permalink(); ?>"><?php the_excerpt(); ?></a></h3>
 																			</div>
 																		</div>
 

--- a/css/main.css
+++ b/css/main.css
@@ -1011,14 +1011,11 @@ div.wpcf7 img.ajax-loader {
 .entry {
   text-align: justify;
   line-height: 2.2;
-  text-overflow: ellipsis;
-  overflow: auto;
 }
 .entry p {
   line-height: 2.2;
   font-size: 1.1rem;
   margin-bottom: 30px;
-  text-overflow: ellipsis;
 }
 .entry ul {
   padding-left: 25px;
@@ -1051,6 +1048,27 @@ div.wpcf7 img.ajax-loader {
   font-size: 4rem;
   color: #ccc;
 }
+.entry .read::after {
+  content: ">";
+  padding-left: 5px;
+}
+.entry .read {
+  display: block;
+  width: 50%;
+  padding: 10px 0;
+  background: #15274D;
+  color: white;
+  text-align: center;
+  margin: 15px auto 50px;
+  -webkit-transition-duration: .2s;
+          transition-duration: .2s;
+  border: 1px solid #15274D;
+  font-weight: bold;
+}
+.entry .read:hover {
+  color: #15274D;
+  background-color: white;
+}
 .entry img {
   max-width: 100%;
 }
@@ -1078,8 +1096,9 @@ div.wpcf7 img.ajax-loader {
 }
 
 .lp-wrapper {
-  max-width: 1920px;
+  max-width: 2560px;
   width: 100%;
+  margin: 0 auto;
   line-height: normal;
 }
 
@@ -1613,6 +1632,10 @@ hr {
   .lp-topbar p {
     font-size: 1rem;
     padding: 3px 0;
+  }
+
+  .entry {
+    margin-top: 80px;
   }
 }
 @media screen and (max-width: 600px) and (orientation: portrait) {

--- a/css/main.css
+++ b/css/main.css
@@ -1011,11 +1011,14 @@ div.wpcf7 img.ajax-loader {
 .entry {
   text-align: justify;
   line-height: 2.2;
+  text-overflow: ellipsis;
+  overflow: auto;
 }
 .entry p {
   line-height: 2.2;
   font-size: 1.1rem;
   margin-bottom: 30px;
+  text-overflow: ellipsis;
 }
 .entry ul {
   padding-left: 25px;

--- a/functions.php
+++ b/functions.php
@@ -123,7 +123,7 @@ add_filter('excerpt_more', 'cms_excerpt_more');
 // 抜粋文が自動的に生成される場合にデフォルトの文字数を変更します。
 function cms_excerpt_length()
 {
-    return 55;
+    return 20;
 }
 add_filter('excerpt_mblength', 'cms_excerpt_length');
 

--- a/functions.php
+++ b/functions.php
@@ -82,6 +82,7 @@ function change_child_pages_shortcode_css()
 }
 add_filter('child-pages-shortcode-stylesheet', 'change_child_pages_shortcode_css');
 
+
 // ウィジェット
 register_sidebar(array(
         'name' => 'サイドバーウィジェットエリア（上）',

--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -281,10 +281,14 @@ div.wpcf7 img.ajax-loader {
 .entry {
   text-align: justify;
   line-height: 2.2;
+  text-overflow: ellipsis;
+  overflow: auto;
+
 p {
   line-height: 2.2;
   font-size: 1.1rem;
   margin-bottom: 30px;
+  text-overflow: ellipsis;
 }
  ul {
   padding-left: 25px;

--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -281,14 +281,10 @@ div.wpcf7 img.ajax-loader {
 .entry {
   text-align: justify;
   line-height: 2.2;
-  text-overflow: ellipsis;
-  overflow: auto;
-
 p {
   line-height: 2.2;
   font-size: 1.1rem;
   margin-bottom: 30px;
-  text-overflow: ellipsis;
 }
  ul {
   padding-left: 25px;
@@ -321,6 +317,28 @@ blockquote {
     color: #ccc;
     }
 }
+
+.read::after {
+    content: ">";
+    padding-left: 5px;
+}
+.read {
+    display: block;
+    width: 50%;
+    padding: 10px 0;
+    background: #15274D;
+    color: white;
+    text-align: center;
+    margin: 15px auto 50px;
+    transition-duration: .2s;
+    border: 1px solid #15274D;
+    font-weight: bold;
+    &:hover {
+      color: #15274D;
+      background-color: white;
+    }
+}
+
 img {
   max-width: 100%;
 }
@@ -346,8 +364,9 @@ img {
 }
 
 .lp-wrapper {
-  max-width: 1920px;
+  max-width: 2560px;
   width: 100%;
+  margin: 0 auto;
   line-height: normal;
 }
 .lpplan-top {
@@ -832,6 +851,11 @@ hr {
     font-size: 1rem;
     padding: 3px 0;
 }
+
+.entry {
+  margin-top: 80px;
+}
+
 }
 
 @media screen and (max-width:600px) and (orientation:portrait) {


### PR DESCRIPTION
ただし、クロムのデベロッパーツールで再現しないため、対応が困難。
blogエリアをscroll可能にすることで対応した。
